### PR TITLE
utils, glob & postActions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,30 @@
 # Change Log
 
+### [0.9.7] - 8.07.2022
+- glob pattern support for paths in `info.js > files`
+- `postActions` / `asyncPostActions` added, look at `template.ts`
+- `utils` injection into `info.js` config, with following methods `exec(cmd):Promise, execSync(cmd)`
+
+Example for usage inside template manifest:
+```javascript
+// info.js
+{
+    //...
+    asyncPostActions: async function (vfs, variablesContext) {
+        await this.utils.exec('./scripts/any')
+    },
+    // & sync version
+    postActions: async function (vfs, variablesContext) {
+        await this.utils.execSync('pwd')
+    }
+    //...
+}
+```
+
+### [0.9.6] - 4.06.2022
+- async ejs templating
+- asyncPostProcessor added
+
 ### [0.9.3 - 0.9.4] - 26.02.2022
 
 - fixed first install from sources, with npm/yarn, added typescript + X-flag for launching exec

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lr-module-gen",
   "url": "https://github.com/1is10/lr-module-gen",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "",
   "main": "dist/index.js",
   "bin": {
@@ -21,10 +21,12 @@
     "@types/ejs": "^3.1.0",
     "blessed": "^0.1.81",
     "ejs": "^3.1.6",
+    "glob": "8.0.3",
     "yargs": "^17.3.1"
   },
   "devDependencies": {
     "@types/blessed": "^0.1.19",
+    "@types/glob": "^7.2.0",
     "@types/node": "^17.0.6",
     "@types/yargs": "^17.0.8",
     "typescript": "^4.5.5"

--- a/src/utils/globUtils.ts
+++ b/src/utils/globUtils.ts
@@ -1,0 +1,17 @@
+import * as glob from "glob"
+import * as path from "path"
+
+export const globPromise = (cwd: string, pattern: string): Promise<string[]> => {
+    return new Promise<string[]>((resolve, reject) => {
+        glob.glob(pattern, {
+            cwd,
+            absolute: true
+        }, (err, matches) => {
+            if (err != null) {
+                return reject(err)
+            }
+
+            return resolve(matches.map(file => path.relative(cwd, file)))
+        })
+    })
+}

--- a/src/vfs/index.ts
+++ b/src/vfs/index.ts
@@ -15,7 +15,6 @@ export const isVFSString = (nodeOrNot: VFSNode | string): nodeOrNot is string =>
     return typeof nodeOrNot === "string"
 }
 
-
 export const flattenVFS = (vfs: VFSNode, rootPath?: string): { [key: string]: string } => {
     let paths: { [key: string]: string } = {}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,19 @@
   resolved "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.0.tgz"
   integrity sha512-DCg+Ka+uDQ31lJ/UtEXVlaeV3d6t81gifaVWKJy4MYVVgvJttyX/viREy+If7fz+tK/gVxTGMtyrFPnm4gjrVA==
 
+"@types/glob@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
 "@types/node@*", "@types/node@^17.0.6":
   version "17.0.6"
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.6.tgz"
@@ -72,6 +85,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -149,15 +169,44 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+glob@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -180,6 +229,20 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -222,6 +285,11 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Added glob pattern support for paths in `info.js > files`
Added support for `postActions` / `asyncPostActions` in `info.js`, look at `template.ts`
Added `utils` injection into `info.js` config, with following methods `exec(cmd):Promise, execSync(cmd)`